### PR TITLE
pychatl 2.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip install pylint codecov nosexcover
   - cd python

--- a/javascript/src/parser.spec.js
+++ b/javascript/src/parser.spec.js
@@ -5,6 +5,29 @@ describe('the pegjs parser', function () {
 
   const tests = [
     {
+      'it': 'should parse content with carriage return',
+      'dsl': `%[lights_on]\r\n  turn the lights on\r\n%[lights_off]\r\n  turn the lights off`,
+      'expected': {
+          'intents': {
+              'lights_on': {
+                  'props': {},
+                  'data': [
+                      [{'type': 'text', 'value': 'turn the lights on'}],
+                  ],
+              },
+              'lights_off': {
+                  'props': {},
+                  'data': [
+                      [{'type': 'text', 'value': 'turn the lights off'}],
+                  ],
+              },
+          },
+          'entities': {},
+          'synonyms': {},
+          'comments': [],
+      },
+    },
+    {
       it: 'should parse simple intents with props',
       dsl: `
 %[get_forecast](some=prop, something=else)

--- a/python/pychatl/parser.py
+++ b/python/pychatl/parser.py
@@ -9,7 +9,7 @@ from arpeggio.cleanpeg import ParserPEG, visit_parse_tree
 PARSER = ParserPEG("""
 root = (intent_definition / entity_definition / synonym_definition / comment / EOL)+
 
-EOL = r'\\n|\\r'
+EOL = r'\\n|\\r\\n'
 indent = r'[ \\t]*'
 sentence = r'[^@^~^%^#^\\n^\\r]+'
 text = r'[^\\n^\\r]*'

--- a/python/pychatl/version.py
+++ b/python/pychatl/version.py
@@ -1,2 +1,2 @@
 # pylint: disable=C0111
-__version__ = '2.0.2'
+__version__ = '2.0.3'

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -10,6 +10,29 @@ class TestParser:
     def test_it_should_correctly_parse_dsl(self):
         tests = [
             {
+                'it': 'should parse content with carriage return',
+                'dsl': """%[lights_on]\r\n  turn the lights on\r\n%[lights_off]\r\n  turn the lights off""",
+                'expected': {
+                    'intents': {
+                        'lights_on': {
+                            'props': {},
+                            'data': [
+                                [{'type': 'text', 'value': 'turn the lights on'}],
+                            ],
+                        },
+                        'lights_off': {
+                            'props': {},
+                            'data': [
+                                [{'type': 'text', 'value': 'turn the lights off'}],
+                            ],
+                        },
+                    },
+                    'entities': {},
+                    'synonyms': {},
+                    'comments': [],
+                },
+            },
+            {
                 'it': 'should parse simple intents with props',
                 'dsl': """
 %[get_forecast](some=prop, something=else)


### PR DESCRIPTION
* fix: carriage return breaks python parser
* ci: Add python 3.8 target