### PR TITLE
Correct license

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=README,
     url='https://github.com/atlassistant/chatl',
     author='Julien LEICHER',
-    license='GPL-3.0',
+    license='MIT',
     packages=find_packages(),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
`setup.py` has GPL 3.0 listed as the license but everything else indicates that it's MIT.